### PR TITLE
docs: add Cursor Cloud Storybook setup instructions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,22 @@
+# AGENTS.md
+
+## Cursor Cloud specific instructions
+
+This repo is a **frontend-only pnpm monorepo** (Kona Editor). There is **no backend, database, or external service** — "running" the product means running Node-based dev/build/test tooling. Toolchain per CI (`.github/workflows/gh-pages.yml`): **Node 20+, pnpm 10** (the VM currently has Node 22 / pnpm 10, which works fine).
+
+Workspaces (`pnpm-workspace.yaml`):
+- `packages/editor` → `@use-kona/editor`, the publishable Slate-based React rich-text editor library.
+- `apps/site` → `@kona/site`, an Rspress docs/demo site that consumes the editor via `workspace:*`.
+
+Standard commands (see `package.json` scripts; run from repo root unless noted):
+- Lint: `pnpm run lint` (Biome).
+- Test: `pnpm --filter @use-kona/editor test` (Vitest, jsdom).
+- Build library: `pnpm run build:editor`; Build site: `pnpm run build:site`.
+- Site dev server: `pnpm --filter @kona/site dev`.
+- Storybook (component playground): `pnpm --filter @use-kona/editor storybook`.
+
+Non-obvious caveats:
+- The site dev server serves under the base path `/editor/`, i.e. open **http://localhost:3000/editor/** (not `/`). The homepage embeds the live editor (`apps/site/docs/index.tsx` → `examples/Editor.tsx`), so it's the quickest way to manually exercise editor functionality.
+- `pnpm install` prints "Ignored build scripts" (esbuild, core-js, @parcel/watcher). This is expected and harmless here — builds, tests, and the dev server all work without approving them (rslib/rspress use Rspack, not esbuild's native binary). Do **not** run the interactive `pnpm approve-builds`.
+- Pre-existing issues unrelated to your changes (present on `dev`): `pnpm run lint` reports Biome errors/warnings, and Vitest has one failing test in `packages/editor/src/plugins/ListsPlugin/ListsPlugin.spec.tsx` ("should change current block to numbered list"). Don't assume you broke these; verify against the base branch.
+- There is a nested `packages/editor/pnpm-lock.yaml`, but installs are driven by the root lockfile via workspaces — always install from the repo root.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,11 +12,12 @@ Standard commands (see `package.json` scripts; run from repo root unless noted):
 - Lint: `pnpm run lint` (Biome).
 - Test: `pnpm --filter @use-kona/editor test` (Vitest, jsdom).
 - Build library: `pnpm run build:editor`; Build site: `pnpm run build:site`.
-- Site dev server: `pnpm --filter @kona/site dev`.
-- Storybook (component playground): `pnpm --filter @use-kona/editor storybook`.
+- Build Storybook: `pnpm --filter @use-kona/editor build:storybook`.
+- Primary component-development UI: `pnpm --filter @use-kona/editor exec storybook dev --ci --port 6006`.
 
 Non-obvious caveats:
-- The site dev server serves under the base path `/editor/`, i.e. open **http://localhost:3000/editor/** (not `/`). The homepage embeds the live editor (`apps/site/docs/index.tsx` → `examples/Editor.tsx`), so it's the quickest way to manually exercise editor functionality.
+- The package-level `storybook` script does not specify a port, so Storybook may choose a random available port in a non-interactive cloud shell. Use the explicit command above and open **http://localhost:6006/**.
+- Storybook builds and starts, but the existing stories currently fail at runtime: `packages/editor/stories/Editor.stories.tsx` imports `ExampleEditor` from `../src`, while that symbol exists only in `apps/site/examples/Editor.tsx` and is not exported by `packages/editor/src/index.ts`. Fix this application-code issue before relying on Storybook stories for manual editor testing.
 - `pnpm install` prints "Ignored build scripts" (esbuild, core-js, @parcel/watcher). This is expected and harmless here — builds, tests, and the dev server all work without approving them (rslib/rspress use Rspack, not esbuild's native binary). Do **not** run the interactive `pnpm approve-builds`.
 - Pre-existing issues unrelated to your changes (present on `dev`): `pnpm run lint` reports Biome errors/warnings, and Vitest has one failing test in `packages/editor/src/plugins/ListsPlugin/ListsPlugin.spec.tsx` ("should change current block to numbered list"). Don't assume you broke these; verify against the base branch.
 - There is a nested `packages/editor/pnpm-lock.yaml`, but installs are driven by the root lockfile via workspaces — always install from the repo root.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Sets up and verifies the development environment for Kona Editor, with **Storybook as the primary component-development UI**, and documents durable cloud-agent guidance in `AGENTS.md`.

No application code was modified.

## Environment setup

- Toolchain: Node 22 / pnpm 10 (CI targets Node 20 / pnpm 10).
- Automatic dependency refresh: `pnpm install`.
- Storybook dev server: `pnpm --filter @use-kona/editor exec storybook dev --ci --port 6006`.

## Verification

| Task | Command | Result |
|------|---------|--------|
| Install | `pnpm install` | Pass |
| Storybook build | `pnpm --filter @use-kona/editor build:storybook` | Pass |
| Storybook dev server | explicit port command above | Pass; HTTP 200 at `http://localhost:6006/` |
| Story index | `GET /index.json` | Pass; Docs, Editor, Deserialize, Serialize indexed |
| Editor library build | `pnpm run build:editor` | Pass |
| Unit tests | `pnpm --filter @use-kona/editor test` | Runs; 1 pass, 1 pre-existing failure |
| Lint | `pnpm run lint` | Runs; pre-existing Biome diagnostics |

## Runtime caveat discovered

Storybook itself builds and runs, but all existing editor stories fail to render because `packages/editor/stories/Editor.stories.tsx` imports `ExampleEditor` from `../src`; that symbol is only defined in `apps/site/examples/Editor.tsx` and is not exported from `packages/editor/src/index.ts`. Fixing this requires an application-code change, which is intentionally outside this environment-setup-only PR.

The Storybook process remains running on port 6006 for continued testing.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-1497e240-caf2-4e94-a096-c22ca9274387"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1497e240-caf2-4e94-a096-c22ca9274387"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

