### PR TITLE
Prevent default when Escape blurs the editor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 This fill will contain all the changes for `@use-kona/editor`
 since version `0.1.11`.
 
+## 0.1.27
+### Core
+**Fixed**
+* Prevented the default Escape behavior when clearing block selection and blurring the editor.
+
 ## 0.1.26
 ### ListsPlugin
 **Added**

--- a/packages/editor/package.json
+++ b/packages/editor/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@use-kona/editor",
-  "version": "0.1.26",
+  "version": "0.1.27",
   "type": "module",
   "exports": {
     ".": "./src/index.ts"

--- a/packages/editor/src/core/createEditable.tsx
+++ b/packages/editor/src/core/createEditable.tsx
@@ -118,6 +118,7 @@ export const createEditable =
         if ($selectedNodes.length === 0) {
           selectedNodes.set([currentBlock[0]]);
         } else {
+          event.preventDefault();
           selectedNodes.set([]);
           ReactEditor.blur(editor);
         }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
When Escape is pressed a second time (clearing block selection and blurring the editor), call `event.preventDefault()` so the browser does not also handle the key.

Also bumps `@use-kona/editor` to `0.1.27` and updates the changelog.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f94c6-2e3b-7867-be9a-84dd3c9232da"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f94c6-2e3b-7867-be9a-84dd3c9232da"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

